### PR TITLE
Update backup in progress marker file check

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -144,6 +144,7 @@ backup_grace_period_in_days = 10
 ;expected_rows = <Number of rows expected to be returned when the query runs. Not checked if not specified.>
 ;expected_result = <Coma separated string representation of values returned by the query. Checks only 1st row returned, and only if specified>
 ;enable_md5_checks = <During backups and verify, use md5 calculations to determine file integrity (in addition to size, which is used by default)>
+;max_backup_marker_age = <Age in hours at which medusa considers a node's medusa_backup_in_progress marker file to be stale. If the marker file is stale, it will be deleted, and a new backup will be allowed to start. Defaults to 48 hours.>
 
 [logging]
 ; Controls file logging, disabled by default.

--- a/medusa-example.ini
+++ b/medusa-example.ini
@@ -157,7 +157,7 @@ use_sudo_for_restore = True
 ;expected_rows = <Number of rows expected to be returned when the query runs. Not checked if not specified.>
 ;expected_result = <Coma separated string representation of values returned by the query. Checks only 1st row returned, and only if specified>
 ;enable_md5_checks = <During backups and verify, use md5 calculations to determine file integrity (in addition to size, which is used by default)>
-
+;max_backup_marker_age = <Age in hours at which medusa considers a node's medusa_backup_in_progress marker file to be stale. If the marker file is stale, it will be deleted, and a new backup will be allowed to start. Defaults to 48 hours.>
 
 [logging]
 ; Controls file logging, disabled by default.
@@ -192,5 +192,3 @@ use_sudo_for_restore = True
 ;ca_cert = mutual_auth_ca.pem
 ;tls_cert = mutual_auth_client.crt
 ;tls_key = mutual_auth_client.key
-
-

--- a/medusa/backup_node.py
+++ b/medusa/backup_node.py
@@ -83,7 +83,7 @@ def handle_backup(config, backup_name_arg, stagger_time, enable_md5_checks_flag,
 
     # externalise the fact a backup is running.
     # we need a way to tell a backup is running without invoking Meudsa to prevent concurrency and abrupt termination
-    backup_in_progress_marker = medusa.utils.MedusaTempFile()
+    backup_in_progress_marker = medusa.utils.MedusaTempFile(config.checks.max_backup_marker_age)
     if backup_in_progress_marker.exists():
         marker_path = backup_in_progress_marker.get_path()
         raise IOError(

--- a/medusa/config.py
+++ b/medusa/config.py
@@ -51,7 +51,7 @@ SSHConfig = collections.namedtuple(
 
 ChecksConfig = collections.namedtuple(
     'ChecksConfig',
-    ['health_check', 'query', 'expected_rows', 'expected_result', 'enable_md5_checks']
+    ['health_check', 'query', 'expected_rows', 'expected_result', 'enable_md5_checks', 'max_backup_marker_age']
 )
 
 MonitoringConfig = collections.namedtuple(
@@ -160,7 +160,8 @@ def _build_default_config():
         'query': '',
         'expected_rows': '0',
         'expected_result': '',
-        'enable_md5_checks': 'false'
+        'enable_md5_checks': 'false',
+        'max_backup_marker_age': 48
     }
 
     config['monitoring'] = {

--- a/medusa/utils.py
+++ b/medusa/utils.py
@@ -40,16 +40,14 @@ class MedusaTempFile(object):
             pass
 
     def exists(self):
-        if self._tempfile is not None:
-            try:
-                return pathlib.Path(self._tempfile_path).exists()
-            except Exception:
-                logging.warning(
-                    f'Could not check for running backup marker {self._tempfile_path}. Assuming a backup is not running'
-                )
-                return False
-        else:
+        try:
+            return pathlib.Path(self._tempfile_path).exists()
+        except Exception:
+            logging.warning(
+                f'Could not check for running backup marker {self._tempfile_path}. Assuming a backup is not running'
+            )
             return False
+
 
     def get_path(self):
         return self._tempfile_path

--- a/medusa/utils.py
+++ b/medusa/utils.py
@@ -23,14 +23,16 @@ from datetime import datetime, timedelta, timezone
 
 class MedusaTempFile(object):
 
-    _tempfile = None
-    _tempfile_path = f'{tempfile.gettempdir()}/medusa_backup_in_progress'
+    def __init__(self, max_backup_marker_age):
+        self._max_backup_marker_age = max_backup_marker_age
+        self._tempfile = None
+        self._tempfile_path = f'{tempfile.gettempdir()}/medusa_backup_in_progress'
 
     def _is_stale(self):
         try:
             path = pathlib.Path(self._tempfile_path)
             file_time = datetime.fromtimestamp(path.stat().st_mtime, timezone.utc)
-            return datetime.now(timezone.utc) - file_time > timedelta(hours=48)
+            return datetime.now(timezone.utc) - file_time > timedelta(hours=self._max_backup_marker_age)
         except Exception:
             return False
 

--- a/tests/integration/features/steps/integration_steps.py
+++ b/tests/integration/features/steps/integration_steps.py
@@ -1806,7 +1806,7 @@ def _backup_has_server_type_and_release_version(context, backup_name, server_typ
 
 @then(u'I can tell a backup "{is_in_progress}" in progress')
 def _backup_is_or_is_not_in_progress(context, is_in_progress):
-    marker_file_path = MedusaTempFile().get_path()
+    marker_file_path = MedusaTempFile(context.medusa_config.checks.max_backup_marker_age).get_path()
     if 'is' == is_in_progress:
         assert Path(marker_file_path).exists()
     if 'is not' == is_in_progress:


### PR DESCRIPTION
* Fix the check so it actually works
* Ignore marker files that were created over `max_backup_marker_age` hours ago (48 by default)