### PR TITLE
Add medusa.purge_decommissioned import to cli

### DIFF
--- a/medusa/medusacli.py
+++ b/medusa/medusacli.py
@@ -43,6 +43,7 @@ import medusa.download
 import medusa.index
 import medusa.listing
 import medusa.purge
+import medusa.purge_decommissioned
 import medusa.report_latest
 import medusa.restore_cluster
 import medusa.restore_node


### PR DESCRIPTION
Else:
```
$ medusa purge-decommissioned
[2025-08-14 21:13:55,306] WARNING: Forcing use_sudo to False because Kubernetes mode is enabled
Traceback (most recent call last):
  File "/usr/share/cassandra-medusa/bin/medusa", line 8, in <module>
    sys.exit(cli())
  File "/usr/share/cassandra-medusa/lib/python3.10/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/usr/share/cassandra-medusa/lib/python3.10/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/usr/share/cassandra-medusa/lib/python3.10/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/share/cassandra-medusa/lib/python3.10/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/share/cassandra-medusa/lib/python3.10/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/usr/share/cassandra-medusa/lib/python3.10/site-packages/click/decorators.py", line 92, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/usr/share/cassandra-medusa/lib/python3.10/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/usr/share/cassandra-medusa/lib/python3.10/site-packages/medusa/medusacli.py", line 373, in purge_decommissioned
    medusa.purge_decommissioned.main(medusaconfig)
AttributeError: module 'medusa' has no attribute 'purge_decommissioned'
```